### PR TITLE
Consider replies without Re: as WR

### DIFF
--- a/src/mail.rs
+++ b/src/mail.rs
@@ -181,7 +181,6 @@ pub fn fetch_wrs(
         let mut sequence_set: Vec<_> = sequence_set.into_iter().collect();
         sequence_set.sort();
         let sequence_set: String = join(sequence_set.into_iter().map(|s| s.to_string()), ",");
-        
         // Fetch the messages
         let messages = imap_session.fetch(sequence_set, "ENVELOPE")?;
 


### PR DESCRIPTION
Yo Tim,

Super cool project. I love it!

It wasn't working for me because when I send my WR, I go to my previous WR and click on "Reply to all" to create a new email with the same person in cc as my previous WR. Thus with the current implementation, it considers my WR in my sent mailbox as replies and filters them out.

To circumvent this, I just look for the Re: (Aw: in German) in the subject. 

PS: You should share this on the WR list it's awesome! And it should be in the PULP Platform GitHub organization!